### PR TITLE
Fixed 'nasa9polynomials.xml' path.

### DIFF
--- a/thermopy/nasa9polynomials.py
+++ b/thermopy/nasa9polynomials.py
@@ -177,9 +177,9 @@ class Database(object):
     """
 
     def __init__(self):
-        self._nasa9 = ET.parse(str(os.path.dirname(
-                                   os.path.dirname(__file__)) + "/databases/" +
-                                   'nasa9polynomials.xml'))
+        xmlPath = os.path.join(os.path.dirname(__file__),
+            os.pardir, 'databases', 'nasa9polynomials.xml')
+        self._nasa9 = ET.parse(os.path.abspath(xmlPath))
         self._root = self._nasa9.getroot()
 
     def _search_database(self, x):


### PR DESCRIPTION
This didn't worked for me (using Python 2.7.6):
```python
>>> from thermopy import nasa9polynomials as nasa9
>>> db = nasa9.Database()
```

Now it does.